### PR TITLE
addr-book-upgrade: fix Junos version parsing

### DIFF
--- a/library/juniper/op/installation/addr-book-upgrade/addr-book-downgrade.slax
+++ b/library/juniper/op/installation/addr-book-upgrade/addr-book-downgrade.slax
@@ -175,7 +175,7 @@ template get-junos-version() {
 
      var $osrelease = jcs:sysctl("kern.osrelease", "s");
 
-     var $version = jcs:split("[IRB-]", $osrelease, 2);
+     var $version = jcs:split("[IRBSX-]", $osrelease, 2);
 
      expr $version[1];
 

--- a/library/juniper/op/installation/addr-book-upgrade/addr-book-upgrade.slax
+++ b/library/juniper/op/installation/addr-book-upgrade/addr-book-upgrade.slax
@@ -124,7 +124,7 @@ template get-junos-version() {
 
      var $osrelease = jcs:sysctl("kern.osrelease", "s");
 
-     var $version = jcs:split("[IRB-]", $osrelease, 2);
+     var $version = jcs:split("[IRBSX-]", $osrelease, 2);
 
      expr $version[1];
 }


### PR DESCRIPTION
The Junos version parsing in addr-book-upgrade is broken, but easily fixed.