### PR TITLE
Create hashtag.py

### DIFF
--- a/library/juniper/op/display/hashtag/hashtag.py
+++ b/library/juniper/op/display/hashtag/hashtag.py
@@ -1,0 +1,50 @@
+from jnpr.junos import Device
+from jnpr.junos.utils.config import Config
+from lxml import etree
+import string
+import argparse
+
+arguments = {'hashtag': 'Configuration element hash tag'}
+
+def build_xml_filter( root, element):
+    path = []
+    s = ''
+    
+    while element!= root:
+        name = element.find( 'name')
+        if name!=None:
+            s = '<name>'+name.text+'</name>'+s            
+        s = '<'+element.tag + '>'+s+'</'+element.tag+'>'
+        element = element.getparent()
+    return s
+    
+def main():
+
+    parser = argparse.ArgumentParser(description='Displays configuration elements with select hashtag. Hashtags are configured at any level using "set apply-macro ht <hashtag-name>" command.')
+    
+    for key in arguments:
+        parser.add_argument(('-' + key), required=True, help=arguments[key])
+    args = parser.parse_args()
+
+    dev = Device()
+    dev.open()
+    dev.timeout = 300
+    xml_config = dev.rpc.get_config(options={'database':'committed','inherit':'inherit'})    
+    paths = []
+    #select all elements matching pattern
+    for ht_element in xml_config.findall( './/apply-macro/data/[name=\'{}\']/../'.format( args.hashtag)):
+        #filter by node id just in case        
+        if ht_element.text == 'ht':
+            s = build_xml_filter( xml_config, ht_element.getparent().getparent())
+            paths.append( s)
+    if paths:
+        path = '<configuration>'+"".join( paths)+'</configuration>'    
+        xml_config = dev.rpc.get_config( filter_xml=path,options={'database':'committed','inherit':'inherit', 'format':'text'})
+        print xml_config.text
+    else:
+        print 'hashtag \'{}\' is not found'.format( args.hashtag)
+    dev.close()
+
+    
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The script displays configuration elements matching a certain value of the 'ht' parameter configured through an apply-macro statement. It helps to display relevant information to a particular customer, or any other object.
See an example below.
--
regress@rppdt-mx480f> op hashtag.py hashtag d39934ce111a864abf40391f3da9cdf5 

## Last commit: 2018-03-07 23:32:35 PST by regress
interfaces {
    interface-set CUSTOMER_0005 {
        apply-macro ht {
            d39934ce111a864abf40391f3da9cdf5;
        }
        interface ae14 {
            vlan-tags-outer 5;
        }
    }
}
## Last commit: 2018-03-07 23:32:35 PST by regress
interfaces {
    ae14 {
        unit 20 {
            apply-macro ht {
                d39934ce111a864abf40391f3da9cdf5;
            }
            forwarding-class-accounting {
                direction both;
            }
            description "to rppdt-mx480a ae14.20 : Customer-5 private_primary";
            vlan-tags outer 5 inner 20;
            family inet {
                filter {
                    output global-private-out-v4;
                    group 2;
                }
                input-hierarchical-policer CUSTOMER_0005-common-in;
                address 10.1.0.34/30;
            }
            family inet6 {
                address fd00:0010:0001:0000:0000:0000:0000:0022/126;
            }
        }
    }
}