### PR TITLE
Add a directory for disabling interface configs

### DIFF
--- a/library/juniper/Authors/jgarrison.xml
+++ b/library/juniper/Authors/jgarrison.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<author>
-  <full-name>Jessica Garrison</full-name>
-  <company>Juniper Networks</company>
-  <email>jessica@juniper.net</email>
-  <location>USA</location>
-</author>

--- a/library/juniper/Authors/jgarrison.xml
+++ b/library/juniper/Authors/jgarrison.xml
@@ -1,0 +1,27 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2709
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fnil\fcharset0 Lato-Regular;\f1\froman\fcharset0 Times-Roman;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;\red255\green255\blue255;\red0\green0\blue0;
+}
+{\*\expandedcolortbl;;\cssrgb\c0\c1\c1;\cssrgb\c100000\c100000\c99985\c0;\cssrgb\c0\c0\c0;
+}
+\margl1440\margr1440\vieww19080\viewh12260\viewkind0
+\deftab720
+\pard\pardeftab720\partightenfactor0
+
+\f0\fs37\fsmilli18667 \cf2 \cb3 \expnd0\expndtw0\kerning0
+<?xml version="1.0"?>\
+<author>\
+  <full-name>Jessica Garrison</full-name>\
+  <company>Juniper Networks</company>\
+  <email>jessica@juniper.net</email>\
+  <location>USA</location>\
+</author>
+\f1\fs24 \cf2 \cb3 \
+\
+\
+\pard\pardeftab720\partightenfactor0
+\cf4 \cb2 \
+\
+\cb1 \
+\
+}

--- a/library/juniper/Authors/jgarrison.xml
+++ b/library/juniper/Authors/jgarrison.xml
@@ -1,27 +1,7 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2709
-\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fnil\fcharset0 Lato-Regular;\f1\froman\fcharset0 Times-Roman;}
-{\colortbl;\red255\green255\blue255;\red0\green0\blue0;\red255\green255\blue255;\red0\green0\blue0;
-}
-{\*\expandedcolortbl;;\cssrgb\c0\c1\c1;\cssrgb\c100000\c100000\c99985\c0;\cssrgb\c0\c0\c0;
-}
-\margl1440\margr1440\vieww19080\viewh12260\viewkind0
-\deftab720
-\pard\pardeftab720\partightenfactor0
-
-\f0\fs37\fsmilli18667 \cf2 \cb3 \expnd0\expndtw0\kerning0
-<?xml version="1.0"?>\
-<author>\
-  <full-name>Jessica Garrison</full-name>\
-  <company>Juniper Networks</company>\
-  <email>jessica@juniper.net</email>\
-  <location>USA</location>\
+<?xml version="1.0"?>
+<author>
+  <full-name>Jessica Garrison</full-name>
+  <company>Juniper Networks</company>
+  <email>jessica@juniper.net</email>
+  <location>USA</location>
 </author>
-\f1\fs24 \cf2 \cb3 \
-\
-\
-\pard\pardeftab720\partightenfactor0
-\cf4 \cb2 \
-\
-\cb1 \
-\
-}

--- a/library/juniper/event/interfaces/disable-the-down-down-interfaces/disable-the-down-down-interfaces.conf
+++ b/library/juniper/event/interfaces/disable-the-down-down-interfaces/disable-the-down-down-interfaces.conf
@@ -1,0 +1,14 @@
+event-options {
+    generate-event {
+        weekly time-interval 604800 no-drift;
+    }
+    inactive: policy weekly-disable-interfaces {
+        events weekly;
+        then {
+            event-script disable-the-down-down-interfaces.slax;
+        }
+    }                                   
+    event-script {
+        file disable-the-down-down-interfaces.slax;
+    }
+}

--- a/library/juniper/event/interfaces/disable-the-down-down-interfaces/disable-the-down-down-interfaces.slax
+++ b/library/juniper/event/interfaces/disable-the-down-down-interfaces/disable-the-down-down-interfaces.slax
@@ -1,0 +1,48 @@
+/*
+* Disables interfaces that are showing a down/down status
+*/
+ 
+version 1.0;
+ns junos = "http://xml.juniper.net/junos/*/junos";
+ns xnm = "http://xml.juniper.net/xnm/1.1/xnm";
+ns jcs = "http://xml.juniper.net/junos/commit-scripts/1.0";
+ 
+import "../import/junos.xsl";
+ 
+match / {
+ 
+    /* Open connection with mgd and show interfaces terse */
+    var $rpc = {
+            <get-interface-information> {
+                <terse>;
+            }
+        }
+    var $con = jcs:open();
+    var $int = jcs:execute($con, $rpc);
+ 
+    /* Only down down interfaces */
+    var $down-interfaces = $int/physical-interface[admin-status == 'down' && oper-status == 'down'];
+
+    /* Disable configuration for only the down/down interfaces */
+    var $xml := {
+        <configuration> {
+            for-each ( $down-interfaces ) {
+                <interfaces> {
+                    <interface> {
+                    <name> name;
+                    <disable>;
+                    }
+                }
+            }
+        }
+    }
+
+    /* Use load then commit the configuration */
+    var $results := {
+        call jcs:load-configuration($connection = $con, $configuration = $xml);
+    }
+ 
+    /* Close the mgd connection */
+    expr jcs:close($con);
+ 
+}

--- a/library/juniper/event/interfaces/disable-the-down-down-interfaces/disable-the-down-down-interfaces.xml
+++ b/library/juniper/event/interfaces/disable-the-down-down-interfaces/disable-the-down-down-interfaces.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <script>
-<author>jgarrison</author>
 <title>disable-the-down-down-interfaces.slax</title>
 <synopsis>
 This event script disables the interfaces which are already down.

--- a/library/juniper/event/interfaces/disable-the-down-down-interfaces/disable-the-down-down-interfaces.xml
+++ b/library/juniper/event/interfaces/disable-the-down-down-interfaces/disable-the-down-down-interfaces.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<script>
+<author>jgarrison</author>
+<title>disable-the-down-down-interfaces.slax</title>
+<synopsis>
+This event script disables the interfaces which are already down.
+</synopsis>
+<coe>event</coe>
+<type>interfaces</type>
+
+<description>
+This event script is confiigured to run on a weekly basis.  It grabs the "show interfaces terse" command and checks for the Admin and Link statuses to be down.  If they are both down, it disables the interfaces configuration. 
+</description>
+
+ <example>
+ <title>Config</title>
+ <config>disable-the-down-down-interfaces.conf</config>
+ </example>
+
+<xhtml:script xmlns:xhtml="http://www.w3.org/1999/xhtml"
+src="../../../../../web/leaf.js" 
+type="text/javascript"/>
+</script>

--- a/library/juniper/op/display/show-interface-status-2/show-interface-status-2.xml
+++ b/library/juniper/op/display/show-interface-status-2/show-interface-status-2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<script>
+<author>jgarrison</author>
+<title>show-interface-status.slax</title>
+<synopsis>
+Grabs information from show interfaces and show ethernet-switching commands and places then into one output. 
+</synopsis>
+<coe>op</coe>
+<type>display</type>
+
+<description>
+This op script outputs Port, Description, Status, VLAN ID, Tagging, Duplex, and Speed for each VLAN by interface. 
+</description>
+
+<xhtml:script xmlns:xhtml="http://www.w3.org/1999/xhtml"
+src="../../../../../web/leaf.js" 
+type="text/javascript"/>
+</script>

--- a/library/juniper/op/display/show-interface-status-2/show-interfaces-status-2.slax
+++ b/library/juniper/op/display/show-interface-status-2/show-interfaces-status-2.slax
@@ -1,4 +1,4 @@
-version 1.0;
+version 1.2;
 
 ns junos = "http://xml.juniper.net/junos/*/junos";
 ns xnm = "http://xml.juniper.net/xnm/1.1/xnm";
@@ -29,7 +29,10 @@ match / {
         <output> jcs:printf( "%-20s%-27s%-11s%-12s%-20s%-16s%-18s", "Port", "Description", "Status", "VLAN ID", "Tagging", "Duplex", "Speed");
         
         for-each ( $eth/l2ng-l2ald-iff-interface-entry[string-length(l2iff-interface-vlan-id) > 0] ) {
-                <output> jcs:printf( "%-20s%-27s%-11s%-12s%-20s%-16s%-18s", l2iff-interface-name, $int/physical-interface/link-level-type, $int/physical-interface/oper-status, l2iff-interface-vlan-id, l2iff-interface-vlan-member-tagness, $int/physical-interface/link-type, $int/physical-interface/speed);
+            var $etname = substring-before(l2iff-interface-name,".");
+            if (($int/physical-interface[name==$etname]/admin-status=="up") && ($int/physical-interface[name==$etname]/oper-status=="up")) {
+                <output> jcs:printf( "%-20s%-27s%-11s%-12s%-20s%-16s%-18s", l2iff-interface-name, $int/physical-interface[name==$etname]/link-level-type, $int/physical-interface[name==$etname]/oper-status, l2iff-interface-vlan-id, l2iff-interface-vlan-member-tagness, $int/physical-interface[name==$etname]/link-type, $int/physical-interface[name==$etname]/speed);
+            }
         }
     }
 }

--- a/library/juniper/op/display/show-interface-status-2/show-interfaces-status-2.slax
+++ b/library/juniper/op/display/show-interface-status-2/show-interfaces-status-2.slax
@@ -1,0 +1,35 @@
+version 1.0;
+
+ns junos = "http://xml.juniper.net/junos/*/junos";
+ns xnm = "http://xml.juniper.net/xnm/1.1/xnm";
+ns jcs = "http://xml.juniper.net/junos/commit-scripts/1.0";
+
+import "../import/junos.xsl";
+
+match / {
+    <op-script-results> {
+
+        /* show interfaces extensive to capture description, status, duplex, and speed */
+        var $rpc1 = {
+            <get-interface-information> {
+                <extensive>;
+            }
+        }
+        var $int = jcs:invoke( $rpc1 );
+
+        /* show ethernet-switching interfaces to capture port, vlan id, and tagging */
+        var $rpc2 = {
+            <get-ethernet-switching-interface-details> {
+                <detail>;
+            }
+        }
+        var $eth = jcs:invoke( $rpc2 );
+
+        /* print the header */
+        <output> jcs:printf( "%-20s%-27s%-11s%-12s%-20s%-16s%-18s", "Port", "Description", "Status", "VLAN ID", "Tagging", "Duplex", "Speed");
+        
+        for-each ( $eth/l2ng-l2ald-iff-interface-entry[string-length(l2iff-interface-vlan-id) > 0] ) {
+                <output> jcs:printf( "%-20s%-27s%-11s%-12s%-20s%-16s%-18s", l2iff-interface-name, $int/physical-interface/link-level-type, $int/physical-interface/oper-status, l2iff-interface-vlan-id, l2iff-interface-vlan-member-tagness, $int/physical-interface/link-type, $int/physical-interface/speed);
+        }
+    }
+}

--- a/library/juniper/op/display/show-interface-status-2/show-interfaces-status-2.slax
+++ b/library/juniper/op/display/show-interface-status-2/show-interfaces-status-2.slax
@@ -28,9 +28,16 @@ match / {
         /* print the header */
         <output> jcs:printf( "%-20s%-27s%-11s%-12s%-20s%-16s%-18s", "Port", "Description", "Status", "VLAN ID", "Tagging", "Duplex", "Speed");
         
+        /* for loop with the vlan ids, ignore the empty ones */
         for-each ( $eth/l2ng-l2ald-iff-interface-entry[string-length(l2iff-interface-vlan-id) > 0] ) {
+            
+            /* grabbing the name of the physical interface ignoring the .0 */
             var $etname = substring-before(l2iff-interface-name,".");
-            if (($int/physical-interface[name==$etname]/admin-status=="up") && ($int/physical-interface[name==$etname]/oper-status=="up")) {
+
+            /* confirmation of Admin and Link status, only print when both are up */
+            if (($int/physical-interface[name==$etname]/admin-status=="up") && ($int/physical-interface[name==$etname]/oper-status=="down")) {
+
+                /* print each line */
                 <output> jcs:printf( "%-20s%-27s%-11s%-12s%-20s%-16s%-18s", l2iff-interface-name, $int/physical-interface[name==$etname]/link-level-type, $int/physical-interface[name==$etname]/oper-status, l2iff-interface-vlan-id, l2iff-interface-vlan-member-tagness, $int/physical-interface[name==$etname]/link-type, $int/physical-interface[name==$etname]/speed);
             }
         }

--- a/library/juniper/op/display/storm-control/storm-control.slax
+++ b/library/juniper/op/display/storm-control/storm-control.slax
@@ -1,0 +1,31 @@
+version 1.0;
+
+ns junos = "http://xml.juniper.net/junos/*/junos";
+ns xnm = "http://xml.juniper.net/xnm/1.1/xnm";
+ns jcs = "http://xml.juniper.net/junos/commit-scripts/1.0";
+
+import "../import/junos.xsl";
+
+match / {
+    <op-script-results> {
+
+        /* show interfaces extensive to capture unicast, broadcast, and multicast traffic */
+        var $rpc = {
+            <get-interface-information> {
+                <extensive>;
+            }
+        }
+        var $int = jcs:invoke( $rpc );
+
+        var $eth = jcs:invoke( "get-ethernet-switching-interface-details" );
+        <output> jcs:printf( "%-23s%-18s%-18s%-18s%-18s%-18s%-18s", "Interface Name", "Unicast RX", "Unicast TX", "Broadcast RX", "Broadcast TX", "Multicast RX", "Multicast TX");
+
+        for-each ( $eth/l2ng-l2ald-iff-interface-entry/l2ng-l2ald-iff-interface-entry[l2iff-interface-flags == "SCTL"] ) {
+            var $sto-con-int =  substring-before ( l2iff-interface-name, '.' );
+            var $int-eth = $int/physical-interface[name == $sto-con-int ]/ethernet-mac-statistics;
+
+            <output> jcs:printf( "%-23s%-18s%-18s%-18s%-18s%-18s%-18s", $sto-con-int, $int-eth/input-unicasts, $int-eth/output-unicasts, $int-eth/input-broadcasts, $int-eth/output-broadcasts, $int-eth/input-multicasts, $int-eth/output-multicasts);
+
+        }
+    }
+}

--- a/library/juniper/op/display/storm-control/storm-control.xml
+++ b/library/juniper/op/display/storm-control/storm-control.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<script>
+<author>jgarrison</author>
+<title>storm-control.slax</title>
+<synopsis>
+Outputs packet information for storm control tagged interfaces. 
+</synopsis>
+<coe>op</coe>
+<type>display</type>
+
+<description>
+This op script takes the SCTL (storm control flagged) interfaces from the "show ethernet-swtiching interface" command and outputs the unicast, broadcast, and multicast traffic data. 
+</description>
+
+<xhtml:script xmlns:xhtml="http://www.w3.org/1999/xhtml"
+src="../../../../../web/leaf.js" 
+type="text/javascript"/>
+</script>


### PR DESCRIPTION
This directory under library/juniper/event/interfaces contains the conf, slax, and xml files related to a slax script that disables the interface configuration of an interface when the Admin and Link statuses are both down.